### PR TITLE
Improve argument type error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = (str, opts) => {
 	if (typeof str !== 'string') {
-		throw new Error('Expected a string');
+		throw new TypeError('Expected a string, got ' + typeof str);
 	}
 
 	opts = Object.assign({resolve: true}, opts);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = (str, opts) => {
 	if (typeof str !== 'string') {
-		throw new TypeError('Expected a string, got ' + typeof str);
+		throw new TypeError(`Expected a string, got ${typeof str}`);
 	}
 
 	opts = Object.assign({resolve: true}, opts);


### PR DESCRIPTION
since the error is thrown when not a string type passed, maybe is a good idea to throw a type error indicating what type was given instead