### PR TITLE
Escape ? and # in file and directory names

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,5 +21,7 @@ module.exports = (str, opts) => {
 		pathName = `/${pathName}`;
 	}
 
-	return encodeURI(`file://${pathName}`);
+	// Escape required characters for path components
+	// See: https://tools.ietf.org/html/rfc3986#section-3.3
+	return encodeURI(`file://${pathName}`).replace(/[?#]+/g, encodeURIComponent);
 };

--- a/test.js
+++ b/test.js
@@ -11,6 +11,10 @@ test('converts path to file url', t => {
 	}
 });
 
+test('escapes reserved characters in path', t => {
+	t.regex(m('Bad?/A#1.jpg'), /^file:\/\/\/.*\/Bad%3F\/A%231.jpg$/);
+});
+
 test('accepts resolve parameter', t => {
 	t.is(m('test.jpg', {resolve: false}), 'file:///test.jpg');
 });


### PR DESCRIPTION
`'?'` and `'#'` signal the end of the path component of the URL and can appear in file and directory names on some platforms (e.g. Linux).  Per [RFC 3986 Section 3.3](https://tools.ietf.org/html/rfc3986#section-3.3) (referenced by [draft-ietf-appsawg-file-scheme Section 3.1](https://tools.ietf.org/html/draft-ietf-appsawg-file-scheme-03#section-3.1)) these should be URL-encoded as:

```javascript
fileUrl('/Whose files?/C#.jpg') === 'file:///Whose%20files%3F/C%23.jpg'
```
It is currently returned as:
```javascript
fileUrl('/tmp/Whose files?/C#.jpg') === 'file:///Whose%20files?/C#.jpg'
```
This PR fixes that.