### PR TITLE
Removed exports section and added dependent package path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,40 @@
 {
-	"name": "file-url",
-	"version": "4.0.0",
-	"description": "Convert a file path to a file url: `unicorn.jpg` → `file:///Users/sindresorhus/unicorn.jpg`",
-	"license": "MIT",
-	"repository": "sindresorhus/file-url",
-	"funding": "https://github.com/sponsors/sindresorhus",
-	"author": {
-		"name": "Sindre Sorhus",
-		"email": "sindresorhus@gmail.com",
-		"url": "https://sindresorhus.com"
-	},
-	"type": "module",
-	"exports": "./index.js",
-	"engines": {
-		"node": ">=12"
-	},
-	"scripts": {
-		"test": "xo && ava && tsd"
-	},
-	"files": [
-		"index.js",
-		"index.d.ts"
-	],
-	"keywords": [
-		"file",
-		"url",
-		"uri",
-		"path",
-		"scheme",
-		"slash"
-	],
-	"devDependencies": {
-		"ava": "^3.15.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.38.2"
-	}
+  "name": "file-url",
+  "version": "4.0.0",
+  "description": "Convert a file path to a file url: `unicorn.jpg` → `file:///Users/sindresorhus/unicorn.jpg`",
+  "license": "MIT",
+  "repository": "sindresorhus/file-url",
+  "funding": "https://github.com/sponsors/sindresorhus",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=12"
+  },
+  "scripts": {
+    "test": "xo && ava && tsd"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
+  "keywords": [
+    "file",
+    "url",
+    "uri",
+    "path",
+    "scheme",
+    "slash"
+  ],
+  "dependencies": {
+    "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "ava": "^3.15.0",
+    "tsd": "^0.14.0",
+    "xo": "^0.38.2"
+  }
 }


### PR DESCRIPTION
1. This package has a dependency on the package 'path' but it was not declared as a dependency in the package.json
2. With Node 14 or higher, declaring the exports section in the package.json without also including the package.json file itself will generate a warning during build.  Removing the exports section from the package.json resolves the warning.  See https://github.com/react-native-community/cli/issues/1168 for more details.