### PR TITLE
Don't convert backslashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,6 @@ export default function fileUrl(filePath, options = {}) {
 		pathName = path.resolve(filePath);
 	}
 
-	pathName = pathName.replace(/\\/g, '/');
-
 	// Windows drive letter must be prefixed with a slash.
 	if (pathName[0] !== '/') {
 		pathName = `/${pathName}`;


### PR DESCRIPTION
not sure why it was added in the first place but it seems to be causing problems here: https://github.com/mifi/lossless-cut/issues/1941

e.g. on macos when trying to encode a file name with a backslash in it, it causes the backslashe to interpreted as forward slashes, which is not correct and causes the process opening the file to fail.

example: 

```
require('file-url')('/path/to/file/with\\backslash.mp4') -> file:///path/to/file/with/backslash.mp4
```

it should become `file:///path/to/file/with%5Cbackslash.mp4`